### PR TITLE
Removed logging.fileConfig call with hardcoded path

### DIFF
--- a/ppl/types/notary.py
+++ b/ppl/types/notary.py
@@ -13,7 +13,6 @@ import logging
 from ppl.types.iou import StateType
 from ppl.types.notary_journal import NotaryJournal
 import logging.config
-logging.config.fileConfig('../logging.conf')
 log = logging.getLogger("Notary")
 
 


### PR DESCRIPTION
This breaks execution of anything from the top-level directory, eg
tests, and in any case isn't the right place to do this